### PR TITLE
Bump org.springframework-version in /Last_Pro

### DIFF
--- a/Last_Pro/pom.xml
+++ b/Last_Pro/pom.xml
@@ -9,7 +9,7 @@
 	<version>1.0.0-BUILD-SNAPSHOT</version>
 	<properties>
 		<java-version>1.8</java-version>
-		<org.springframework-version>5.1.1.RELEASE</org.springframework-version>
+		<org.springframework-version>5.2.6.RELEASE</org.springframework-version>
 		<org.aspectj-version>1.6.10</org.aspectj-version>
 		<org.slf4j-version>1.6.6</org.slf4j-version>
 	</properties>


### PR DESCRIPTION
Bumps `org.springframework-version` from 5.1.1.RELEASE to 5.2.6.RELEASE.

Updates `spring-context` from 5.1.1.RELEASE to 5.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.1.RELEASE...v5.2.6.RELEASE)

Updates `spring-webmvc` from 5.1.1.RELEASE to 5.2.6.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v5.1.1.RELEASE...v5.2.6.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>